### PR TITLE
docker-compose file for ghost blogging platform

### DIFF
--- a/docker/ghost/docker-compose.yaml
+++ b/docker/ghost/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  ghost:
+    image: ghost:latest
+    container_name: ghost_app
+    restart: always
+    ports:
+      - "8000:2368"
+    depends_on:
+      - db
+    environment:
+      url: http://localhost:8000
+      database__client: mysql
+      database__connection__host: db
+      database__connection__user: root
+      database__connection__password: ramanath
+      database__connection__database: ghost
+    volumes:
+      - /opt/ghost/ghost_content:/var/lib/ghost/content
+
+  db:
+    image: mysql:5.7
+    container_name: ghost_db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ramanath
+    volumes:
+      - /opt/ghost/ghost_mysql:/var/lib/mysql
+


### PR DESCRIPTION
This PR contains docker-compose file for ghost platform. For the database part we have mysql as a db service and mounted the mysql data into /opt/ghost/ directory